### PR TITLE
Added ZwTerminateProcess to list of dangerous functions

### DIFF
--- a/DriverBuddyReloaded/vulnerable_functions_lists/winapi.py
+++ b/DriverBuddyReloaded/vulnerable_functions_lists/winapi.py
@@ -199,6 +199,7 @@ winapi_function_prefixes = [
     # ZwSetInformationTransaction
     # ZwSetValueKey
     # ZwSinglePhaseReject
+    # ZwTerminateProcess
     # ZwUnloadDriver
     # ZwUnmapViewOfSection
     # ZwWriteFile


### PR DESCRIPTION
ZwTerminateProcess can be used to terminate any process in the system (even protected processes such as AVs).
See also: https://youtu.be/ViWLMfSwGVA