### PR TITLE
Fixed an error message that would occassionally occur due to a branch…

### DIFF
--- a/DriverBuddyReloaded.py
+++ b/DriverBuddyReloaded.py
@@ -428,6 +428,7 @@ class DriverBuddyPlugin(idaapi.plugin_t):
         :return:
         """
         try:
+            pool = None
             with open(analysis_file_name, "w") as log_file:
                 print("\nDriver Buddy Reloaded Auto-analysis\n"
                       "-----------------------------------------------")


### PR DESCRIPTION
If the plugin is ran on a non-driver file the branch previously at ``line 446`` would never run causing the pool local variable to never be initialized. In turn this would cause an error message ``UnboundLocalError: cannot access local variable 'pool'`` where it is not associated with a value on ``line 482``. This fix is a simple addition in order to alleviate this issue.